### PR TITLE
Feature/next previous page

### DIFF
--- a/server/apps/jukebox/generator/buttons.js
+++ b/server/apps/jukebox/generator/buttons.js
@@ -1,6 +1,5 @@
 import { addWebhookWithClick } from "./playlistGenerator.js";
 import { InteractiveAsset } from "../../../utils/index.js";
-import req from "express/lib/request.js";
 
 export const addPlaylistFrame = async ({ id, position, req, urlSlug }) => {
   try {
@@ -55,4 +54,66 @@ export const addNextButton = async ({ id, position, req, urlSlug }) => {
   } catch (e) {
     console.log("Error adding next button", e);
   }
+};
+
+export const addPreviousPageButton = async ({ id, position, req, urlSlug }) => {
+  addPageButton({
+    pos: {
+      x: position ? position.x - 100 : -100,
+      y: position ? position.y + 1000 : 1000,
+    },
+    req,
+    text: "Previous Page",
+    uniqueName: `sdk-examples_playlist_${id}_control_previous_page`,
+    urlSlug,
+    dataObject: { action: "previous-page-clicked", jukeboxId: id },
+  });
+};
+
+export const addNextPageButton = async ({ id, position, req, urlSlug }) => {
+  addPageButton({
+    pos: {
+      x: position ? position.x + 100 : 100,
+      y: position ? position.y + 1000 : 1000,
+    },
+    req,
+    text: "Next Page",
+    uniqueName: `sdk-examples_playlist_${id}_control_next_page`,
+    urlSlug,
+    dataObject: { action: "next-page-clicked", jukeboxId: id },
+  });
+};
+
+const addPageButton = async ({
+  pos,
+  req,
+  text,
+  uniqueName,
+  urlSlug,
+  dataObject,
+}) => {
+  // Will replace this once have previous and next buttons.
+  const droppedAsset = await createText({
+    pos,
+    req,
+    text,
+    textSize: 20,
+    textWidth: 100,
+    uniqueName,
+    urlSlug,
+  });
+
+  const description = `${text} button clicked`;
+  const title = `${text} clicked`;
+  const clickableTitle = `${text} clicked`;
+
+  addWebhookWithClick({
+    clickableTitle,
+    dataObject,
+    description,
+    req,
+    title,
+    droppedAsset,
+    urlSlug,
+  });
 };

--- a/server/apps/jukebox/generator/buttons.js
+++ b/server/apps/jukebox/generator/buttons.js
@@ -1,5 +1,6 @@
 import { addWebhookWithClick } from "./playlistGenerator.js";
 import { InteractiveAsset } from "../../../utils/index.js";
+import { createText } from "./text.js";
 
 export const addPlaylistFrame = async ({ id, position, req, urlSlug }) => {
   try {
@@ -60,7 +61,7 @@ export const addPreviousPageButton = async ({ id, position, req, urlSlug }) => {
   addPageButton({
     pos: {
       x: position ? position.x - 100 : -100,
-      y: position ? position.y + 1000 : 1000,
+      y: position ? position.y + 850 : 850,
     },
     req,
     text: "Previous Page",
@@ -74,7 +75,7 @@ export const addNextPageButton = async ({ id, position, req, urlSlug }) => {
   addPageButton({
     pos: {
       x: position ? position.x + 100 : 100,
-      y: position ? position.y + 1000 : 1000,
+      y: position ? position.y + 850 : 850,
     },
     req,
     text: "Next Page",
@@ -98,7 +99,7 @@ const addPageButton = async ({
     req,
     text,
     textSize: 20,
-    textWidth: 100,
+    textWidth: 150,
     uniqueName,
     urlSlug,
   });

--- a/server/apps/jukebox/generator/playlistGenerator.js
+++ b/server/apps/jukebox/generator/playlistGenerator.js
@@ -1,7 +1,12 @@
 // TODO: Add 'next page' and 'previous page' buttons to in-world playlist so can browse through the entire playlist
 
 import { getAssetAndDataObject, World } from "../../../utils/index.js";
-import { addPlaylistFrame, addNextButton } from "./buttons.js";
+import {
+  addPlaylistFrame,
+  addPreviousPageButton,
+  addNextButton,
+  addNextPageButton,
+} from "./buttons.js";
 import { updatePlaylist } from "./updatePlaylist.js";
 
 // TODO replace Track to change highlighting when it's playing
@@ -24,14 +29,26 @@ export const addPlaylistToWorld = async (req, res) => {
     });
 
     addPlaylistFrame({
-      apiKey,
       id: assetId,
       position: { ...position, y: position.y + addPosOffset },
       req,
       urlSlug,
     });
     addNextButton({
-      apiKey,
+      id: assetId,
+      position: { ...position, y: position.y + addPosOffset },
+      req,
+      urlSlug,
+    });
+
+    addPreviousPageButton({
+      id: assetId,
+      position: { ...position, y: position.y + addPosOffset },
+      req,
+      urlSlug,
+    });
+
+    addNextPageButton({
       id: assetId,
       position: { ...position, y: position.y + addPosOffset },
       req,

--- a/server/apps/jukebox/generator/updatePlaylist.js
+++ b/server/apps/jukebox/generator/updatePlaylist.js
@@ -69,6 +69,8 @@ export const updatePlaylist = ({
 
     // End of playlist
     // if (i < mediaLinkPlaylist.length) {
+    // console.log("start", start);
+    // console.log("videoIndex", videoIndex);
     if (isAdding)
       addTrack({
         id: assetId,
@@ -101,7 +103,7 @@ export const updatePlaylist = ({
           textWidth: 300,
         },
         req,
-        text: mediaLinkPlaylist[videoIndex]?.snippet?.title,
+        text: mediaLinkPlaylist[videoIndex]?.snippet?.title || "-",
         uniqueName: `sdk-examples_playlist_${assetId}_track_${index}`,
       });
     }

--- a/server/apps/jukebox/index.js
+++ b/server/apps/jukebox/index.js
@@ -5,6 +5,8 @@ export {
 export { updatePlaylist } from "./generator/updatePlaylist.js";
 export {
   addToAssetPlaylist,
+  nextPage,
+  previousPage,
   removeFromAssetPlaylist,
   shufflePlaylist,
   volumeDown,

--- a/server/routes/webhookRoutes.js
+++ b/server/routes/webhookRoutes.js
@@ -1,6 +1,11 @@
 import express from "express";
 const router = express.Router();
-import { playNextSongInPlaylist, updateMedia } from "../apps/jukebox/index.js";
+import {
+  nextPage,
+  previousPage,
+  playNextSongInPlaylist,
+  updateMedia,
+} from "../apps/jukebox/index.js";
 import { getAssetAndDataObject } from "../utils/index.js";
 export default router;
 
@@ -34,6 +39,15 @@ router.post("/playlist/:param?", async (req, res) => {
     let updateObject = req;
     updateObject.body = { ...req.body, assetId };
     playNextSongInPlaylist(updateObject);
+  } else if (dataObject && dataObject.action === "next-page-clicked") {
+    let updateObject = req;
+    let { jukeboxId } = dataObject;
+    updateObject.body = { ...req.body, assetId: jukeboxId };
+    nextPage(updateObject);
+  } else if (dataObject && dataObject.action === "previous-page-clicked") {
+    let updateObject = req;
+    updateObject.body = { ...req.body, assetId: jukeboxId };
+    previousPage(updateObject);
   }
 
   res.json({ message: "Hello from server!" });

--- a/server/routes/webhookRoutes.js
+++ b/server/routes/webhookRoutes.js
@@ -46,6 +46,7 @@ router.post("/playlist/:param?", async (req, res) => {
     nextPage(updateObject);
   } else if (dataObject && dataObject.action === "previous-page-clicked") {
     let updateObject = req;
+    let { jukeboxId } = dataObject;
     updateObject.body = { ...req.body, assetId: jukeboxId };
     previousPage(updateObject);
   }


### PR DESCRIPTION
## Summary

Adds 'next' and 'previous' page to in-world controls

<br>

## What kind of change does this PR introduce?

New feature

<br>

## Current Behavior

There was no way to change the playlist page

<br>

## New Behavior

Now you can go forwards and backwards through the playlist.  If you are at the end of the playlist, it will cycle back to the first page.  If you are on the first page and click 'previous page', it will cycle to the last page.

<br>

## Does this PR introduce a breaking change?

No breaking changes