### PR TITLE
added windows to the linebreak-style property on eslint

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.js text eol=cr
+*.jsx text eol=cr

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -32,7 +32,7 @@ module.exports = {
         allowSingleLine: true,
       },
     ],
-    "linebreak-style": ["error", "unix"],
+    "linebreak-style": ["error", "unix", "windows"],
     "max-statements-per-line": [
       "error",
       {


### PR DESCRIPTION
## Summary

Adds `windows` to the `linebreak-style` array to prevent linting errors when working on Windows.
adds .gitattributes file

## What kind of change does this PR introduce?

Bugfix

## New Behavior

EOL format should be uniform and not cause linting errors cross OS'

## Does this PR introduce a breaking change?

No

