### PR TITLE
Hotfix/use env for client api domain

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,2 @@
+
+REACT_APP_INSTANCE_DOMAIN=api.topia.io

--- a/client/src/context/GlobalContext.js
+++ b/client/src/context/GlobalContext.js
@@ -84,7 +84,7 @@ function setInteractiveParams({ assetId, dispatch, visitorId, interactiveNonce, 
 // eslint-disable-next-line no-unused-vars
 async function fetchWorld({ apiKey, dispatch, urlSlug }) {
   if (!apiKey || !urlSlug) return;
-  const topia = new Topia({ apiKey });
+  const topia = new Topia({ apiKey, apiDomain: process.env.REACT_APP_INSTANCE_DOMAIN });
   const selectedWorld = new WorldFactory(topia).create(urlSlug);
   const selectedWorldActivity = new WorldActivityFactory(topia).create(urlSlug);
   try {

--- a/client/src/context/UserContext.js
+++ b/client/src/context/UserContext.js
@@ -45,7 +45,7 @@ function useUserDispatch() {
 function fetchUser(apiKey, dispatch) {
   if (!apiKey) return;
   setTimeout(async () => {
-    const topia = new Topia({ apiKey });
+    const topia = new Topia({ apiKey, apiDomain: process.env.REACT_APP_INSTANCE_DOMAIN });
     const user = new UserFactory(topia).create({ apiKey });
     localStorage.setItem("apiKey", apiKey);
     dispatch({ payload: user, type: "FETCH_USER_SUCCESS" });


### PR DESCRIPTION
## Summary

Added `REACT_APP_INSTANCE_DOMAIN` to allow env-driven API domain on the client SDK initialization.
